### PR TITLE
Fix ConcurrentModificationException due to unsafe handling in ExtStorageManager

### DIFF
--- a/src/com/archos/filecorelibrary/ExtStorageManager.java
+++ b/src/com/archos/filecorelibrary/ExtStorageManager.java
@@ -34,6 +34,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Created by noury on 22/06/15.
@@ -60,9 +61,9 @@ public class ExtStorageManager {
     private static Map<String, String> volumesIdMap = new HashMap<>();
 
     static {
-        volumesMap.put(ExtStorageType.SDCARD, new ArrayList<String>(1));
-        volumesMap.put(ExtStorageType.USBHOST, new ArrayList<String>(4));
-        volumesMap.put(ExtStorageType.OTHER, new ArrayList<String>(2));
+        volumesMap.put(ExtStorageType.SDCARD, new CopyOnWriteArrayList<String>());
+        volumesMap.put(ExtStorageType.USBHOST, new CopyOnWriteArrayList<String>());
+        volumesMap.put(ExtStorageType.OTHER, new CopyOnWriteArrayList<String>());
     }
 
     private static final File EXTERNAL_STORAGE_USBHOST_PTP_DIRECTORY = new File("/mnt/ext_camera");

--- a/src/com/archos/filecorelibrary/ExtStorageManager.java
+++ b/src/com/archos/filecorelibrary/ExtStorageManager.java
@@ -256,15 +256,15 @@ public class ExtStorageManager {
     }
 
     public List<String> getExtSdcards() {
-        return volumesMap.get(ExtStorageType.SDCARD);
+        return copyOf(volumesMap.get(ExtStorageType.SDCARD));
     }
 
     public List<String> getExtUsbStorages() {
-        return volumesMap.get(ExtStorageType.USBHOST);
+        return copyOf(volumesMap.get(ExtStorageType.USBHOST));
     }
 
     public List<String> getExtOtherStorages() {
-        return volumesMap.get(ExtStorageType.OTHER);
+        return copyOf(volumesMap.get(ExtStorageType.OTHER));
     }
 
     /**
@@ -304,5 +304,12 @@ public class ExtStorageManager {
         } catch (Exception e) {
             return Environment.MEDIA_REMOVED;
         }
+    }
+
+    /** Creates a copy of a list */
+    private static List<String> copyOf(List<String> list) {
+        if (list == null)
+            return null;
+        return new ArrayList<>(list);
     }
 }


### PR DESCRIPTION
Addresses the following crash and also ensures other outside code like Blacklist can no longer add paths to the lists.

```
2019-09-29 23:18:36.344 31366-31427 E/AndroidRuntime: FATAL EXCEPTION: ImportWorker
    Process: org.courville.nova, PID: 31366
    java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.next(ArrayList.java:860)
        at com.archos.mediaprovider.video.Blacklist.isBlacklisted(Blacklist.java:87)
        at com.archos.mediaprovider.video.VideoStoreImportImpl$Job.<init>(VideoStoreImportImpl.java:242)
        at com.archos.mediaprovider.video.VideoStoreImportImpl.handleScanCursor(VideoStoreImportImpl.java:167)
        at com.archos.mediaprovider.video.VideoStoreImportImpl.doScan(VideoStoreImportImpl.java:315)
        at com.archos.mediaprovider.video.VideoStoreImportImpl.doFullImport(VideoStoreImportImpl.java:100)
        at com.archos.mediaprovider.video.VideoStoreImportService.doImport(VideoStoreImportService.java:338)
        at com.archos.mediaprovider.video.VideoStoreImportService.handleMessage(VideoStoreImportService.java:286)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:214)
        at android.os.HandlerThread.run(HandlerThread.java:65)
```