### PR TITLE
feat: Add detection for .sup (PGS) external subtitles

### DIFF
--- a/src/com/archos/filecorelibrary/MimeUtils.java
+++ b/src/com/archos/filecorelibrary/MimeUtils.java
@@ -378,6 +378,7 @@ public final class MimeUtils {
         add("text/plain", "srt");
         add("text/vtt", "vtt");
         add("text/plain", "ssa");
+        add("application/pgs", "sup");
         add("video/wtv", "wtv");
         // avos extra extensions
         add("audio/avos-adts", "adts");

--- a/src/com/archos/filecorelibrary/StreamOverHttp.java
+++ b/src/com/archos/filecorelibrary/StreamOverHttp.java
@@ -50,7 +50,7 @@ import jcifs.util.transport.TransportException;
 
 /**
  * This is simple HTTP local server for streaming InputStream to apps which are capable to read data from url.
- * Random access input stream is optionally supported, depending if file can be opened in this mode. 
+ * Random access input stream is optionally supported, depending if file can be opened in this mode.
  */
 public class StreamOverHttp {
 	private static final Logger log = LoggerFactory.getLogger(StreamOverHttp.class);
@@ -70,7 +70,7 @@ public class StreamOverHttp {
 	/**
 	 * Some HTTP response status codes
 	 */
-	private static final String 
+	private static final String
 	HTTP_BADREQUEST = "400 Bad Request",
 	HTTP_416 = "416 Range not satisfiable",
 	HTTP_INTERNALERROR = "500 Internal Server Error";
@@ -125,7 +125,7 @@ public class StreamOverHttp {
         mainThread.start();
     }
 
-	private static final String[] SUBTITLES_ARRAY = { "idx", "smi", "ssa", "ass", "srr", "srt", "sub", "mpl", "txt","xml", "vtt"};
+	private static final String[] SUBTITLES_ARRAY = { "idx", "smi", "ssa", "ass", "srr", "srt", "sub", "mpl", "txt","xml", "vtt", "sup"};
 
 	public List<MetaFile2> getSubtitleList(Uri video) throws SftpException, AuthenticationException, JSchException, IOException {
 		if(mSubList!=null)


### PR DESCRIPTION
- StreamOverHttp.java: Add "sup" to SUBTITLES_ARRAY so the file picker surfaces them alongside other subtitle formats.
- MimeUtils.java: Register the "sup" extension with the "application/pgs" MIME type.

This allows the Java layer to successfully recognize .sup files and pass them down to the C backend parser without requiring manual file renaming.

Prerequisites: https://github.com/nova-video-player/aos-avos/pull/6